### PR TITLE
Improve API error handling and flow statistics

### DIFF
--- a/apps/api/src/repositories/pipeline_repo.py
+++ b/apps/api/src/repositories/pipeline_repo.py
@@ -9,14 +9,14 @@ class PipelineRepo:
 
     def list_for_flow(self, flow_id: str, published: Optional[bool] = None) -> List[Pipeline]:
         stmt = select(Pipeline).where(Pipeline.flow_id == flow_id)
-        if published:
+        if published is True:
             stmt = stmt.where(Pipeline.is_published == True)
         elif published is False:
             stmt = stmt.where(Pipeline.is_published == False)
         stmt = stmt.order_by(Pipeline.created_at.desc())
         return list(self.db.execute(stmt).scalars().all())
 
-    def get(self, pid: str) -> Pipeline:
+    def get(self, pid: str) -> Optional[Pipeline]:
         return self.db.get(Pipeline, pid)
 
     def create_version(
@@ -45,8 +45,10 @@ class PipelineRepo:
         self.db.add(p); self.db.flush()
         return p
 
-    def publish(self, pid: str) -> Pipeline:
+    def publish(self, pid: str) -> Optional[Pipeline]:
         p = self.get(pid)
+        if p is None:
+            return None
         # Lock all pipelines of the same flow to avoid concurrent publish races
         _ = (
             self.db.query(Pipeline)

--- a/apps/api/src/repositories/thread_repo.py
+++ b/apps/api/src/repositories/thread_repo.py
@@ -4,6 +4,7 @@ from sqlalchemy import select
 from ..models import Thread, ContextSnapshot, SchemaChannel, Pipeline
 from ..config import settings
 from ..repositories.flow_summary_repo import get_active as get_active_flow_summary
+from ..middleware.error import AppError
 import uuid
 
 class ThreadRepo:
@@ -11,26 +12,34 @@ class ThreadRepo:
         self.db = db
 
     def create(self, thread_id: str, flow_id: str) -> Thread:
-        t = Thread(id=thread_id, flow_id=flow_id)
-        self.db.add(t); self.db.flush()
-        # Context snapshot from active artifacts
-        channel = self.db.execute(select(SchemaChannel).where(SchemaChannel.name==settings.SCHEMA_CHANNEL)).scalar_one_or_none()
-        schema_def_id = channel.active_schema_def_id if channel else None
+        # Ensure schema context is available before mutating session state
+        channel = self.db.execute(
+            select(SchemaChannel).where(SchemaChannel.name == settings.SCHEMA_CHANNEL)
+        ).scalar_one_or_none()
+        if channel is None:
+            raise AppError(status=503, code="SCHEMA_CHANNEL_MISSING", message="No schema channel configured")
+        schema_def_id = channel.active_schema_def_id
         if not schema_def_id:
-            raise ValueError("No schema channel configured")
+            raise AppError(status=503, code="SCHEMA_DEFINITION_MISSING",
+                           message="No active schema definition in the configured channel")
 
         fs = get_active_flow_summary(self.db, flow_id)
-        pub = self.db.execute(select(Pipeline).where(Pipeline.flow_id==flow_id, Pipeline.is_published==True).limit(1)).scalar_one_or_none()
+        pub = self.db.execute(
+            select(Pipeline).where(Pipeline.flow_id == flow_id, Pipeline.is_published == True).limit(1)
+        ).scalar_one_or_none()
 
-        snap = ContextSnapshot(id=str(uuid.uuid4()),
-                               flow_id=flow_id,
-                               origin_thread_id=t.id,
-                               schema_def_id=schema_def_id,
-                               flow_summary_id=fs.id if fs else None,
-                               pipeline_id=pub.id if pub else None,
-                               notes={})
-        self.db.add(snap); self.db.flush()
-        t.context_snapshot_id = snap.id
+        snapshot_id = str(uuid.uuid4())
+        t = Thread(id=thread_id, flow_id=flow_id, context_snapshot_id=snapshot_id)
+        snap = ContextSnapshot(
+            id=snapshot_id,
+            flow_id=flow_id,
+            origin_thread_id=thread_id,
+            schema_def_id=schema_def_id,
+            flow_summary_id=fs.id if fs else None,
+            pipeline_id=pub.id if pub else None,
+            notes={},
+        )
+        self.db.add_all([t, snap])
         self.db.flush()
         return t
 

--- a/apps/api/src/services/flow_service.py
+++ b/apps/api/src/services/flow_service.py
@@ -1,7 +1,10 @@
 import uuid
 from typing import Any, Dict, List
 from sqlalchemy.orm import Session
+
+from ..middleware.error import AppError
 from ..repositories.flow_repo import FlowRepo
+from ..models import Flow
 
 class FlowService:
     def __init__(self, db: Session):
@@ -10,29 +13,42 @@ class FlowService:
     def list(self) -> List[Dict[str, Any]]:
         rows = self.repo.list()
         out: List[Dict[str, Any]] = []
-        for f, has_pub, ver in rows:
-            out.append({
-                "id": str(f.id), "slug": f.slug, "name": f.name,
-                "has_published": has_pub, "active_version": ver
-            })
+        for flow, pub_count, active_ver in rows:
+            out.append(self._serialize(flow, int(pub_count or 0), active_ver))
         return out
 
-    def get_one(self, flow_id: str) -> Dict[str, Any] | None:
-        f = self.repo.get(flow_id)
-        if f is None:
-            return None
-        return dict(id=str(f.id), slug=f.slug, name=f.name)
+    def get_one(self, flow_id: str) -> Dict[str, Any]:
+        row = self.repo.get_with_stats(flow_id)
+        if row is None:
+            raise AppError(status=404, code="FLOW_NOT_FOUND", message="Flow not found")
+        flow, pub_count, active_ver = row
+        return self._serialize(flow, int(pub_count or 0), active_ver)
 
     def create(self, slug: str, name: str) -> Dict[str, Any]:
         fid = str(uuid.uuid4())
         f = self.repo.create(fid, slug, name, meta={})
-        return dict(id=str(f.id), slug=f.slug, name=f.name)
+        return self._serialize(f, 0, None)
 
-    def update(self, flow_id: str, *, name: str | None = None, slug: str | None = None) -> Dict[str, Any] | None:
+    def update(self, flow_id: str, *, name: str | None = None, slug: str | None = None) -> Dict[str, Any]:
+        if name is None and slug is None:
+            raise AppError(status=400, code="FLOW_NOTHING_TO_UPDATE", message="Provide name or slug to update")
         f = self.repo.update(flow_id, name=name, slug=slug)
         if f is None:
-            return None
-        return dict(id=str(f.id), slug=f.slug, name=f.name)
+            raise AppError(status=404, code="FLOW_NOT_FOUND", message="Flow not found")
+        # Flush above ensures DB state is current; fetch aggregated stats for response
+        return self.get_one(flow_id)
 
-    def delete(self, flow_id: str) -> bool:
-        return self.repo.delete(flow_id)
+    def delete(self, flow_id: str) -> None:
+        deleted = self.repo.delete(flow_id)
+        if not deleted:
+            raise AppError(status=404, code="FLOW_NOT_FOUND", message="Flow not found")
+
+    def _serialize(self, flow: Flow, published_count: int, active_version: Any) -> Dict[str, Any]:
+        version = str(active_version) if active_version else None
+        return {
+            "id": str(flow.id),
+            "slug": flow.slug,
+            "name": flow.name,
+            "has_published": published_count > 0,
+            "active_version": version,
+        }

--- a/apps/api/src/services/pipeline_service.py
+++ b/apps/api/src/services/pipeline_service.py
@@ -1,19 +1,29 @@
-import uuid, json, hashlib
+import hashlib
+import json
+import uuid
 from typing import Any, Dict, List
+
+from sqlalchemy import select, func
 from sqlalchemy.orm import Session
-from sqlalchemy import select
-from ..repositories.pipeline_repo import PipelineRepo
-from ..models import SchemaChannel, SchemaDef, Pipeline
+
 from ..config import settings
+from ..middleware.error import AppError
+from ..models import Flow, Pipeline, SchemaChannel, SchemaDef
+from ..repositories.pipeline_repo import PipelineRepo
 
 class PipelineService:
     def __init__(self, db: Session):
         self.db = db
         self.repo = PipelineRepo(db)
 
+    def _require_flow(self, flow_id: str) -> None:
+        if self.db.get(Flow, flow_id) is None:
+            raise AppError(status=404, code="FLOW_NOT_FOUND", message="Flow not found")
+
     def list_for_flow(self, flow_id: str, published: int | None = None) -> List[Dict[str, Any]]:
         # Interpret tri-state query param: None → all, 1 → only published, 0 → only unpublished
         pub_filter = True if published == 1 else False if published == 0 else None
+        self._require_flow(flow_id)
         items = self.repo.list_for_flow(flow_id, pub_filter)
         return [{
             "id": str(p.id), "version": p.version, "status": p.status,
@@ -22,6 +32,8 @@ class PipelineService:
 
     def get(self, pid: str) -> Dict[str, Any]:
         p = self.repo.get(pid)
+        if p is None:
+            raise AppError(status=404, code="PIPELINE_NOT_FOUND", message="Pipeline not found")
         return dict(
             id=str(p.id), flow_id=str(p.flow_id), version=p.version,
             status=p.status, is_published=bool(p.is_published),
@@ -52,13 +64,19 @@ class PipelineService:
 
     def create_version(self, flow_id: str, content: Dict[str, Any], version: str | None = None) -> Pipeline:
         # pick active schema_def from channel
+        self._require_flow(flow_id)
         channel = self.db.execute(select(SchemaChannel).where(SchemaChannel.name==settings.SCHEMA_CHANNEL)).scalar_one_or_none()
         if not channel:
-            raise ValueError("No schema channel configured")
+            raise AppError(status=503, code="SCHEMA_CHANNEL_MISSING", message="No schema channel configured")
         schema_def_id = channel.active_schema_def_id
         if not schema_def_id:
-            raise ValueError("No active schema definition in the configured channel")
-        schema_ver = self.db.get(SchemaDef, schema_def_id).version
+            raise AppError(status=503, code="SCHEMA_DEFINITION_MISSING",
+                           message="No active schema definition in the configured channel")
+        schema_def = self.db.get(SchemaDef, schema_def_id)
+        if schema_def is None:
+            raise AppError(status=503, code="SCHEMA_DEFINITION_MISSING",
+                           message="Active schema definition is not available")
+        schema_ver = schema_def.version
         # derive next version: bump major if schema_def changed since last, else patch
         last = self.db.query(Pipeline).filter(Pipeline.flow_id==flow_id).order_by(Pipeline.created_at.desc()).first()
         if version:
@@ -75,15 +93,14 @@ class PipelineService:
         return p
 
     def publish(self, pipeline_id: str) -> Dict[str, Any]:
-        # Perform publish under transaction (handled by get_db). Repo locks rows to avoid races.
         p = self.repo.publish(pipeline_id)
+        if p is None:
+            raise AppError(status=404, code="PIPELINE_NOT_FOUND", message="Pipeline not found")
         # Conflict detection: ensure exactly one published for the flow
-        from sqlalchemy import select, func
-        from fastapi import HTTPException
         cnt = self.db.execute(
             select(func.count()).select_from(Pipeline).where(Pipeline.flow_id == p.flow_id, Pipeline.is_published == True)
         ).scalar_one()
         if cnt and int(cnt) > 1:
-            # Let the middleware rollback the transaction
-            raise HTTPException(status_code=409, detail="Publish conflict: multiple published versions for this flow")
+            raise AppError(status=409, code="PIPELINE_PUBLISH_CONFLICT",
+                           message="Publish conflict: multiple published versions for this flow")
         return dict(ok=True, flow_id=str(p.flow_id), version=p.version, is_published=True)

--- a/apps/api/src/services/summary_service.py
+++ b/apps/api/src/services/summary_service.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 from datetime import datetime, UTC
 import uuid
 
+from ..middleware.error import AppError
 from ..models import Thread, Message, ThreadSummary, FlowSummary
 from ..services.llm import LLMClient
 
@@ -47,7 +48,7 @@ class SummaryService:
     async def run_thread_summary(self, thread_id: str) -> ThreadSummary:
         t = self.db.get(Thread, thread_id)
         if not t:
-            raise ValueError("Thread not found")
+            raise AppError(status=404, code="THREAD_NOT_FOUND", message="Thread not found")
         # Collect messages for summarization (MVP: whole thread)
         messages_payload = self._collect_messages_payload(thread_id)
         # Call LLM to summarize (mock by default)
@@ -114,7 +115,7 @@ class SummaryService:
         """
         t = self.db.get(Thread, thread_id)
         if not t:
-            raise ValueError("Thread not found")
+            raise AppError(status=404, code="THREAD_NOT_FOUND", message="Thread not found")
         # If already closed, return latest existing summary info without side effects
         if getattr(t, "closed_at", None):
             # Latest thread summary

--- a/apps/api/src/services/thread_service.py
+++ b/apps/api/src/services/thread_service.py
@@ -1,12 +1,18 @@
 import uuid
 from sqlalchemy.orm import Session
+
+from ..middleware.error import AppError
+from ..models import Flow
 from ..repositories.thread_repo import ThreadRepo
 
 class ThreadService:
     def __init__(self, db: Session):
+        self.db = db
         self.repo = ThreadRepo(db)
 
     def create(self, flow_id: str):
+        if self.db.get(Flow, flow_id) is None:
+            raise AppError(status=404, code="FLOW_NOT_FOUND", message="Flow not found")
         tid = str(uuid.uuid4())
         t = self.repo.create(tid, flow_id)
         return dict(id=str(t.id), flow_id=str(t.flow_id), status=t.status, started_at=t.started_at.isoformat())


### PR DESCRIPTION
## Summary
- ensure agent run bookkeeping sessions rollback on failure before closing connections
- expose flow statistics via repository helpers and return AppError-backed responses across flow endpoints
- validate flow/thread/message operations before mutating state, including thread lifecycle guards and schema checks

## Testing
- PYTHONPATH=apps/api/src pytest tests/api -k flow -q *(fails: tests/api missing)*

------
https://chatgpt.com/codex/tasks/task_e_68e4025ea13883308afae1a68614df24