### PR TITLE
Refactor agent runner dependencies for SOLID

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
 import sys
 from pathlib import Path
 
-# Ensure apps/api/src is on sys.path for imports
+# Ensure repository root and apps/api/src are on sys.path for imports
 ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 API_SRC = ROOT / "apps" / "api" / "src"
 if str(API_SRC) not in sys.path:
     sys.path.insert(0, str(API_SRC))

--- a/tests/test_agent_run_suggestion.py
+++ b/tests/test_agent_run_suggestion.py
@@ -2,23 +2,85 @@ from fastapi.testclient import TestClient
 
 from apps.api.src.main import app
 import apps.api.src.routers.agent as agent_router
+from apps.api.src.agent.graph import AgentRunner
 
 
 def test_agent_run_returns_suggestion(monkeypatch):
     # Monkeypatch flow inference to bypass DB
-    monkeypatch.setattr(agent_router, "_infer_flow", lambda thread_id: "flow-1", raising=False)
-    # Monkeypatch SimilarityService to always find a candidate
+    async def _infer_flow(thread_id: str) -> str:
+        return "flow-1"
+
+    monkeypatch.setattr(agent_router, "_infer_flow", _infer_flow, raising=False)
+    # Prepare fake dependencies
     cand = {"pipeline_id": "pip-99", "version": "1.0.0", "score": 1.0}
 
     class _FakeSim:
+        def __init__(self):
+            self.calls = []
+
         def find_candidate(self, flow_id, user_message):
+            self.calls.append((flow_id, user_message))
             return cand
 
-    monkeypatch.setattr(agent_router, "SimilarityService", lambda: _FakeSim(), raising=False)
+    class _FakeSession:
+        def __init__(self):
+            self.commits = 0
+            self.closed = 0
 
-    client = TestClient(app)
-    r = client.post("/threads/abc/agent/run", json={"user_message": {"hello": "world"}, "options": {}})
+        def commit(self):
+            self.commits += 1
+
+        def close(self):
+            self.closed += 1
+
+    class _FakeRunsRepo:
+        def __init__(self):
+            self.actions = []
+
+        def start(self, *args, **kwargs):
+            self.actions.append(("start", args, kwargs))
+
+        def tick(self, *args, **kwargs):
+            self.actions.append(("tick", args, kwargs))
+
+        def finish(self, *args, **kwargs):
+            self.actions.append(("finish", args, kwargs))
+
+        def add_issues(self, *args, **kwargs):  # pragma: no cover - not used but keeps protocol happy
+            self.actions.append(("add_issues", args, kwargs))
+
+    fake_similarity = _FakeSim()
+    sessions: list[_FakeSession] = []
+    repos: list[_FakeRunsRepo] = []
+
+    def _session_factory():
+        s = _FakeSession()
+        sessions.append(s)
+        return s
+
+    def _runs_repo_factory(session):
+        repo = _FakeRunsRepo()
+        repos.append(repo)
+        return repo
+
+    fake_runner = AgentRunner(
+        session_factory=_session_factory,
+        similarity_service=fake_similarity,
+        runs_repo_factory=_runs_repo_factory,
+    )
+
+    app.dependency_overrides[agent_router.get_agent_runner] = lambda: fake_runner
+    try:
+        client = TestClient(app)
+        r = client.post("/threads/abc/agent/run", json={"user_message": {"hello": "world"}, "options": {}})
+    finally:
+        app.dependency_overrides.pop(agent_router.get_agent_runner, None)
+
     assert r.status_code == 200
     data = r.json()
     assert data["ok"] is False
     assert data["suggestion"] == cand
+    # Ensure fake dependencies were used
+    assert fake_similarity.calls == [("flow-1", {"hello": "world"})]
+    assert sessions and sessions[0].commits == 1
+    assert repos and any(action[0] == "finish" for action in repos[0].actions)

--- a/tests/test_agent_runner_injection.py
+++ b/tests/test_agent_runner_injection.py
@@ -1,0 +1,152 @@
+import asyncio
+from types import SimpleNamespace
+
+import apps.api.src.agent.graph as agent_graph
+from apps.api.src.agent.graph import AgentRunner
+
+
+class _FakeBus:
+    def __init__(self):
+        self.events: list[tuple[str, str, dict]] = []
+
+    async def publish(self, key: str, event_type: str, data):
+        self.events.append((key, event_type, data))
+
+
+class _FakeSimilarity:
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+
+    def find_candidate(self, flow_id: str, user_message: dict):
+        self.calls.append((flow_id, user_message))
+        return None
+
+
+class _FakeLLM:
+    def __init__(self):
+        self.generated: list[tuple[dict, dict]] = []
+        self.checked: list[dict] = []
+
+    async def generate_pipeline(self, context: dict, user_message: dict):
+        self.generated.append((context, user_message))
+        return {"stages": [], "meta": "draft"}
+
+    async def self_check(self, draft: dict):
+        self.checked.append(draft)
+        return {"notes": ["ok"], "risks": []}
+
+
+class _FakeValidation:
+    def __init__(self):
+        self.requests: list[dict] = []
+
+    def validate_pipeline(self, pipeline: dict):
+        self.requests.append(pipeline)
+        return []
+
+
+class _FakePipelineService:
+    def __init__(self):
+        self.created: list[tuple[str, dict]] = []
+        self.published: list[str] = []
+
+    def create_version(self, flow_id: str, content: dict):
+        self.created.append((flow_id, content))
+        return SimpleNamespace(id="pip-1", version="1.0.0", status="draft")
+
+    def publish(self, pipeline_id: str):
+        self.published.append(pipeline_id)
+        return {"ok": True}
+
+
+class _FakeRunsRepo:
+    def __init__(self):
+        self.records: list[tuple[str, tuple, dict]] = []
+
+    def start(self, *args, **kwargs):
+        self.records.append(("start", args, kwargs))
+
+    def tick(self, *args, **kwargs):
+        self.records.append(("tick", args, kwargs))
+
+    def finish(self, *args, **kwargs):
+        self.records.append(("finish", args, kwargs))
+
+    def add_issues(self, *args, **kwargs):
+        self.records.append(("add_issues", args, kwargs))
+
+
+class _FakeSession:
+    def __init__(self):
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = 0
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+    def close(self):
+        self.closed += 1
+
+
+def test_agent_runner_uses_injected_dependencies(monkeypatch):
+    fake_bus = _FakeBus()
+    monkeypatch.setattr(agent_graph, "bus", fake_bus, raising=False)
+
+    similarity = _FakeSimilarity()
+    llm = _FakeLLM()
+    validation_service = _FakeValidation()
+    pipeline_service = _FakePipelineService()
+    runs_repo_instances: list[_FakeRunsRepo] = []
+    sessions: list[_FakeSession] = []
+
+    def _session_factory():
+        session = _FakeSession()
+        sessions.append(session)
+        return session
+
+    def _runs_repo_factory(session):
+        repo = _FakeRunsRepo()
+        runs_repo_instances.append(repo)
+        return repo
+
+    def _validation_factory(session):
+        return validation_service
+
+    def _pipeline_factory(session):
+        return pipeline_service
+
+    runner = AgentRunner(
+        session_factory=_session_factory,
+        similarity_service=similarity,
+        llm_client=llm,
+        runs_repo_factory=_runs_repo_factory,
+        validation_service_factory=_validation_factory,
+        pipeline_service_factory=_pipeline_factory,
+    )
+
+    # Avoid touching the real database when gathering context
+    monkeypatch.setattr(runner, "_gather_context", lambda flow_id: {"schema_def": {}, "flow_summary": None, "active_pipeline": None})
+
+    run_id = asyncio.run(runner.run("flow-1", "thread-1", {"msg": "hello"}, {"publish": True}, run_id="run-123"))
+
+    assert run_id == "run-123"
+    assert similarity.calls == [("flow-1", {"msg": "hello"})]
+    assert llm.generated and llm.checked
+    assert validation_service.requests == [{"stages": [], "meta": "draft"}]
+    assert pipeline_service.created == [("flow-1", {"stages": [], "meta": "draft"})]
+    assert pipeline_service.published == ["pip-1"]
+    # ensure runs repo factory was used for each stage
+    assert runs_repo_instances, "RunsRepo factory was not invoked"
+    assert any(
+        rec[0] == "tick" and rec[2].get("stage") == "hard_validate"
+        for repo in runs_repo_instances
+        for rec in repo.records
+    )
+    # sessions should be committed and closed
+    assert sessions and all(sess.closed for sess in sessions)
+    # Bus should have emitted a finished event
+    assert any(evt[1] == "run.finished" for evt in fake_bus.events)


### PR DESCRIPTION
## Summary
- inject AgentRunner dependencies via protocols so core services can be provided externally
- wire the agent router through FastAPI dependencies to share the injected services
- add targeted tests and path setup to exercise dependency overrides without touching real backends

## Testing
- pytest tests/test_agent_run_suggestion.py tests/test_agent_runner_injection.py

------
https://chatgpt.com/codex/tasks/task_e_68e41238c62483309050e53ceef555d0